### PR TITLE
Fix catching exception jonathanraftery/bullhorn-rest-client#4

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -2,6 +2,7 @@
 
 namespace jonathanraftery\Bullhorn\Rest;
 use jonathanraftery\Bullhorn\Rest\Authentication\Client as AuthClient;
+use jonathanraftery\Bullhorn\Rest\Authentication\Exception\InvalidRefreshTokenException;
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Psr7\Request as HttpRequest;


### PR DESCRIPTION
The method InvalidRefreshTokenException in class Client does not catch the exception when no refreshToken is available in the dataStore.