### PR TITLE
Protected Client Properties

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -10,9 +10,9 @@ use GuzzleHttp\Psr7\Uri;
 
 class Client
 {
-    private $authClient;
-    private $httpClient;
-    private $options;
+    protected $authClient;
+    protected $httpClient;
+    protected $options;
 
     public function __construct(
         $clientId,


### PR DESCRIPTION
Hi @jonathanraftery 

This PR makes the properties class protected instead of private.

Reasoning:
* The Bullhorn session auth process is very slow (a few seconds)
* To resolve this I wish to create a maintained session and refresh every few minutes to ensure my application always has an authenticated session
* The Client class's design only allows populates the $httpClient object after the `initiateSession` method (or similar refresh methods) is explicitly called. 
* I want to extend / override the Client class and modify this behavior to set the `httpClient` property in the constructor and utilize the data store to get / retrieve stored session data. This way it will always have a populated httpClient object.
* The the private properties block from (easily) doing this.

Let me know if you think this logic / approach makes sense. 